### PR TITLE
Standardize thumbnails size

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -164,6 +164,11 @@ table td{
   align-items: center;
 }
 
+.post-thumb-img{
+  background-size: cover;
+  height: 12rem;
+}
+
 .post-title{
   margin-bottom: 20px;
   height: 105px;
@@ -185,21 +190,14 @@ table td{
 }
 
 .histories-thumb {
-  min-height: 200px;
-  display: flex;
   align-items: center;
-}
-
-.histories-thumb img{
-  width: 100%;
+  background-size: cover;
+  display: flex;
+  height: 12rem;
 }
 
 .post-thumb a{
   color: black;
-}
-
-.post-thumb img{
-  width: 100%;
 }
 
 .more-posts-link{

--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@ layout: default
     <div class="container">
       <h1>ÚLTIMAS HISTÓRIAS PUBLICADAS</h1>
       <div class="row">
-        <div class="posts-thumb-area"></div>
+        <div class="posts-thumb-area">Carregando…</div>
       </div>
       <div class="row">
         <div class="col-md-12">

--- a/js/app.js
+++ b/js/app.js
@@ -9,8 +9,9 @@ var createHomeThumbs = function (post) {
   var link = document.createElement('a');
   link.setAttribute('href', post.url);
 
-  var img = document.createElement('img');
-  img.setAttribute('src', post.image);
+  var img = document.createElement('div');
+  img.setAttribute('class', 'post-thumb-img');
+  img.setAttribute('style', 'background-image:  url(' + post.image + ')');
 
   var title = document.createElement('h3');
   title.setAttribute('class', 'post-title');
@@ -38,9 +39,7 @@ var createStoriesThumbs = function (post) {
 
   var thumb = document.createElement('div');
   thumb.setAttribute('class', 'histories-thumb');
-
-  var img = document.createElement('img');
-  img.setAttribute('src', post.image);
+  thumb.setAttribute('style', 'background-image:  url(' + post.image + ')');
 
   var d_col = document.createElement('div');
   d_col.setAttribute('class', 'col-md-8');
@@ -57,7 +56,6 @@ var createStoriesThumbs = function (post) {
   d_thumb.appendChild(title);
   d_thumb.appendChild(text);
   d_col.appendChild(d_thumb);
-  thumb.appendChild(img);
   col.appendChild(thumb);
   row.appendChild(col);
   row.appendChild(d_col);
@@ -65,7 +63,7 @@ var createStoriesThumbs = function (post) {
 
   return link;
 
-}
+};
 
 var loadPosts = function (posts) {
 

--- a/js/app.js
+++ b/js/app.js
@@ -1,4 +1,4 @@
-var createThumb = function (post) {
+var createHomeThumbs = function (post) {
 
   var col = document.createElement('div');
   col.setAttribute('class', 'col-md-4');
@@ -25,7 +25,7 @@ var createThumb = function (post) {
 
 };
 
-var createHistThumb = function (post) {
+var createStoriesThumbs = function (post) {
 
   var link = document.createElement('a');
   link.setAttribute('href', post.url);
@@ -64,18 +64,26 @@ var createHistThumb = function (post) {
   link.appendChild(row);
 
   return link;
+
 }
 
 var loadPosts = function (posts) {
-  for (var i = 0; i < 3; i++) {
-      var post = createThumb(posts[i]);
-      $('.posts-thumb-area').append(post);
+
+  var homePosts = $('.posts-thumb-area');
+  if (homePosts.length) {
+    homePosts.empty();
+    for (var i = 0; i < 3; i++) {
+      homePosts.append(createHomeThumbs(posts[i]));
+    }
   }
 
-  posts.forEach(function(post) {
-    var post = createHistThumb(post);
-    $('.histories-thumb-area').append(post);
-  });
+  var storiesPosts = $('.histories-thumb-area');
+  if (storiesPosts.length) {
+      storiesPosts.empty();
+      posts.forEach(function(post) {
+        storiesPosts.append(createStoriesThumbs(post));
+      });
+  }
 };
 
 $(document).ready(function(){

--- a/stories.html
+++ b/stories.html
@@ -4,6 +4,6 @@ layout: default
   <div class="content-block">
     <div class="container">
       <h1>HISTÓRIAS PUBLICADAS</h1>
-      <div class="histories-thumb-area"></div>
+      <div class="histories-thumb-area">Carregando…</div>
     </div>
   </div>


### PR DESCRIPTION
Avoids this:

<img width="959" alt="screen shot 2017-03-14 at 11 43 09" src="https://cloud.githubusercontent.com/assets/4732915/23905968/729e0138-08ab-11e7-9b5a-834794cf949f.png">

In favor of:

<img width="965" alt="screen shot 2017-03-14 at 11 44 12" src="https://cloud.githubusercontent.com/assets/4732915/23906030/9ca989fc-08ab-11e7-8fef-2737ad4a52ff.png">

_Also works in `/stories/`._
