### PR TITLE
Correção na página FAQ: O caso Toblerone foi na Suécia, não na Suíça.

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -173,7 +173,7 @@ layout: default
             <div aria-labelledby="headingSeventeen" class="panel-collapse collapse" id="collapseSeventeen" role="tabpanel">
               <div class="panel-body">
                 <p>Os motivos são três:<br>
-                1 - Nos inspiramos diretamente no famoso Caso Toblerone - um famoso acontecimento onde uma política na Suíça renunciou o seu cargo após ser flagrada com um simples Toblerone na fatura de seu cartão corporativo. Queremos fazer isso: encontrar corrupção em pequenos gastos, mas em volume grande.<br>
+                1 - Nos inspiramos diretamente no famoso Caso Toblerone - um famoso acontecimento onde uma política na Suécia renunciou o seu cargo após ser flagrada com um simples Toblerone na fatura de seu cartão corporativo. Queremos fazer isso: encontrar corrupção em pequenos gastos, mas em volume grande.<br>
                 2 - Parece nome de operação da Polícia Federal, e isso é muito legal.<br>
                 3 - É a nossa Serenata de Amor para o Brasil.</p>
               </div>


### PR DESCRIPTION
Na página FAQ, na sessão que explica o nome do projeto, consta que o Caso Toblerone ocorreu na Suíça, quando na verdade ele ocorreu na Suécia (Referências: [1](https://en.wikipedia.org/wiki/Mona_Sahlin#Political_career), [2](http://blogs.reuters.com/global/2009/05/11/expenses-they-order-this-matter-differently-in-sweden/)).