### PR TITLE
Cleanup

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,9 +48,9 @@ layout: default
         <div class="col-md-12">
           <div class="pull-right">
             {% if site.lang == "en" %}
-              <li class="active"><a href="/en/stories/" class="more-posts-link">{% translate home.more_stories %}</a></li>
+              <a href="/en/stories/" class="more-posts-link">{% translate home.more_stories %}</a>
             {% else %}
-              <li class="active"><a href="/stories/" class="more-posts-link">{% translate home.more_stories %}</a></li>
+              <a href="/stories/" class="more-posts-link">{% translate home.more_stories %}</a>
             {% endif %}
           </div>
         </div>


### PR DESCRIPTION
#30 fixed #29 but inserted a bug in the UI. This clean up fixes it removing unnecessary `<li>` tag.

<img width="1010" alt="pasted_image_09_06_17_08_54" src="https://user-images.githubusercontent.com/4732915/26974347-3f66cba8-4cf1-11e7-95eb-51302753a635.png">