### PR TITLE
Update Rosie stats

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -28,7 +28,7 @@ github:
   repo:             https://github.com/datasciencebr/serenata-website
 
 #i18n
-gems:
+plugins:
                     - jekyll-multiple-languages-plugin
 languages:          ["pt-br", "en"]
 exclude_from_localizations: ["javascript", "css"]

--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -26,9 +26,18 @@ explore:
   reports: Reports
   about_reports: Rosie, our Robot, in numbers
   tweet_about: Tweet about this figure
-  chamber_reports: Cases reported to the Chamber of Deputies
-  suspicions: Different congresspeople reported for suspicious reimbursements
-  questionated: thousand Brazilian Reals questioned in suspicious expenses
+  suspicions:
+    amount: "8,276"
+    description: suspicious reimbursement found
+    tweet: 8.276%20suspicious%20reimbursements%20from%20Brazilian%20representatives%20found%20by%20%40RosieDaSerenata.%20More%20about%20%23SerenataDeAmor%20http%3A%2F%2Fserenatadeamor.org
+  congresspeople:
+    amount: "735"
+    description: Different congresspeople involved in suspicions
+    tweet: 735%20Brazilian%20representatives%20found%20by%20%40RosieDaSerenata%20with%20suspicious%20reimbursements.%20More%20about%20%20%23SerenataDeAmor%20http%3A%2F%2Fserenatadeamor.org
+  money:
+    amount: 3.6M BRL
+    description: found in suspicious reimbursements
+    tweet: 3.6M%20BRL%20found%20in%20suspicions%20reimbursement%20by%20%40RosieDaSerenata.%20More%20about%20%20%23SerenataDeAmor%20http%3A%2F%2Fserenatadeamor.org
   paragraph_one: We reported 629 suspicious reimbursement to the Chamber of Deputies involving 216 different congresspeople and more than 378k BRL.
   paragraph_two: This amount corresponds to 371% of what we raised through our crowdfunding campaign (~US$ 25,000.00)
   paragraph_three: Want to know how the report system works?

--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -29,8 +29,9 @@ explore:
   chamber_reports: Cases reported to the Chamber of Deputies
   suspicions: Different congresspeople reported for suspicious reimbursements
   questionated: thousand Brazilian Reals questioned in suspicious expenses
-  paragraph_one: This amount corresponds to 371% of what we raised through our crowdfunding campaign (~US$ 25,000.00)
-  paragraph_two: Want to know how the report system works?
+  paragraph_one: We reported 629 suspicious reimbursement to the Chamber of Deputies involving 216 different congresspeople and more than 378k BRL.
+  paragraph_two: This amount corresponds to 371% of what we raised through our crowdfunding campaign (~US$ 25,000.00)
+  paragraph_three: Want to know how the report system works?
   more: You can read more in this post (in Portuguese)
 about:
   title: Serenata de Amor Operation

--- a/_i18n/pt-br.yml
+++ b/_i18n/pt-br.yml
@@ -26,9 +26,18 @@ explore:
   reports: Denúncias
   about_reports: A Rosie, nossa Robô, em números
   tweet_about: Tuíte sobre esse número
-  chamber_reports: Denúncias feitas a Câmara dos Deputados
-  suspicions: Deputados diferentes denunciados por gastos suspeitos
-  questionated: mil reais em gastos suspeitos questionados
+  suspicions:
+    amount: "8.276"
+    description: Reembolsos suspeitos encontrados
+    tweet: A%20%40RosieDaSerenata%20j%C3%A1%20encontrou%208.276%20reembolsos%20suspeitos%20dos%20nossos%20deputados%20dos%20nossos%20deputado.%20Saiba%20mais%20sobre%20a%20%23SerenataDeAmor%3A%20http%3A%2F%2Fserenatadeamor.org%0A
+  congresspeople:
+    amount: "735"
+    description: Deputados diferentes encontrados com gastos suspeitos
+    tweet: A%20%40RosieDaSerenata%20j%C3%A1%20encontrou%20reembolsos%20suspeitos%20de%20735%20deputados%20diferentes.%20Saiba%20mais%20sobre%20a%20%23SerenataDeAmor%3A%20http%3A%2F%2Fserenatadeamor.org
+  money:
+    amount: R$ 3,6 mi
+    description: Encontrados em reembolsos suspeitos
+    tweet: A%20%40RosieDaSerenata%20encontrou%20R%24%203%2C6mi%20de%20reembolsos%20suspeitos%20a%20nossos%20deputados.%20Saiba%20mais%20sobre%20a%20%23SerenataDeAmor%20http%3A%2F%2Fserenatadeamor.org
   paragraph_one: Denunciamos 629 reembolsos suspeitos à Câmara dos Deputados, envolvendo 216 deputados diferentes e mais de R$ 378 mil.
   paragraph_two: Esses valores correspondem a 371% do que arrecadamos com nossa campanha de financeamento coletivo (R$ 80.424,00)
   paragraph_three: Quer saber como o processo de denúncias funciona?

--- a/_i18n/pt-br.yml
+++ b/_i18n/pt-br.yml
@@ -29,8 +29,9 @@ explore:
   chamber_reports: Denúncias feitas a Câmara dos Deputados
   suspicions: Deputados diferentes denunciados por gastos suspeitos
   questionated: mil reais em gastos suspeitos questionados
-  paragraph_one: Esses valores correspondem a 371% do que arrecadamos com nossa campanha de financeamento coletivo (R$ 80.424,00)
-  paragraph_two: Quer saber como o processo de denúncias funciona?
+  paragraph_one: Denunciamos 629 reembolsos suspeitos à Câmara dos Deputados, envolvendo 216 deputados diferentes e mais de R$ 378 mil.
+  paragraph_two: Esses valores correspondem a 371% do que arrecadamos com nossa campanha de financeamento coletivo (R$ 80.424,00)
+  paragraph_three: Quer saber como o processo de denúncias funciona?
   more: Você pode ler mais nesse post em nosso blog.
 about:
   title: A operação serenata de amor.

--- a/explore.html
+++ b/explore.html
@@ -7,19 +7,19 @@ layout: default
       <p>{% translate explore.about_reports %}</p>
       <div class="row m-0">
         <div class="col-md-4 p-0">
-          <h4>629</h4>
-          <p>{% translate explore.chamber_reports %}</p>
-          <a class="btn-link" href="https://twitter.com/home?status=A%20Serenata%20fez%20629%20den%C3%BAncias%20feitas%20a%20C%C3%A2mara%20dos%20Deputados.%20Saiba%20mais%20sobre%20a%20%23SerenataDeAmor%3A%20http%3A//serenata.datasciencebr.com" target="_blank"><button class="btn-white">{% translate explore.tweet_about %}</button></a>
+          <h4>{% translate explore.suspicions.amount %}</h4>
+          <p>{% translate explore.suspicions.description %}</p>
+          <a class="btn-link" href="https://twitter.com/home?status={% translate explore.suspicions.tweet %}" target="_blank"><button class="btn-white">{% translate explore.tweet_about %}</button></a>
         </div>
         <div class="col-md-4 p-0">
-          <h4>216</h4>
-          <p>{% translate explore.suspicions %}</p>
-          <a class="btn-link" href="https://twitter.com/home?status=A%20Serenata%20denunciou%20216%20diferentes%20denunciados%20por%20gastos%20suspeitos.%20Saiba%20mais%20sobre%20a%20%23SerenataDeAmor%3A%20http%3A//serenata.datasciencebr.com" target="_blank"><button class="btn-white">{% translate explore.tweet_about %}</button></a>
+          <h4>{% translate explore.congresspeople.amount %}</h4>
+          <p>{% translate explore.congresspeople.description %}</p>
+          <a class="btn-link" href="https://twitter.com/home?status={% translate explore.congresspeople.tweet %}" target="_blank"><button class="btn-white">{% translate explore.tweet_about %}</button></a>
         </div>
         <div class="col-md-4 p-0">
-          <h4>378</h4>
-          <p>{% translate explore.questionated %}</p>
-          <a class="btn-link" href="https://twitter.com/home?status=A%20Serenata%20questionou%20R$%20378%0Amil%20reais%20em%20gastos%20suspeitos.%20Saiba%20mais%20sobre%20a%20%23SerenataDeAmor%3A%20http%3A//serenata.datasciencebr.com" target="_blank"><button class="btn-white">{% translate explore.tweet_about %}</button></a>
+          <h4>{% translate explore.money.amount %}</h4>
+          <p>{% translate explore.money.description %}</p>
+          <a class="btn-link" href="https://twitter.com/home?status={% translate explore.money.tweet %}" target="_blank"><button class="btn-white">{% translate explore.tweet_about %}</button></a>
         </div>
       </div>
     </div>

--- a/explore.html
+++ b/explore.html
@@ -32,7 +32,8 @@ layout: default
     <div class="row">
       <div class="col-md-8 col-md-offset-2 content-block">
         <p>{% translate explore.paragraph_one %}</p>
-        <p>{% translate explore.paragraph_two %} <a href="https://medium.com/data-science-brigade/como-est%C3%A1-acontecendo-a-hackaton-de-den%C3%BAncias-da-opera%C3%A7%C3%A3o-serenata-de-amor-a8bd193e0c76" target='_blank'>{% translate explore.more %}</a>.</p>
+        <p>{% translate explore.paragraph_two %}</p>
+        <p>{% translate explore.paragraph_three %} <a href="https://medium.com/data-science-brigade/como-est%C3%A1-acontecendo-a-hackaton-de-den%C3%BAncias-da-opera%C3%A7%C3%A3o-serenata-de-amor-a8bd193e0c76" target='_blank'>{% translate explore.more %}</a>.</p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
This PR updates _Explore_ page:

* Moves report numbers to a paragraph with less emphasis
* Gives emphasis to figures found by Rosie (independent of the fact that anyone have or have not actually reported this figures)
* Adds numbers to the i18n scheme (so we can use proper separators and abbreviations for each language)
* Updates the suggested tweets
* Adds translated version of tweets for `en`
* Updates `_config.yml` replace deprecated `gems` with `plugins`

I would like to use [`url_encode`](https://shopify.github.io/liquid/filters/url_encode/) to avoid committing encoded version of the tweets, but I couldn't combine `translate` with `url_encode`. Any ideas?