### PR TITLE
footer.html: Fix Jarbas URL on footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -3,7 +3,7 @@
     <div class="row">
       <div class="col-md-4 footer-menu">
         <a href="https://twitter.com/rosiedaserenata" target="_blank">Rosie</a>
-        <a href="https://jarbas.datasciencebr.com" target="_blank">Jarbas</a>
+        <a href="https://jarbas.serenata.ai/" target="_blank">Jarbas</a>
         <a href="https://github.com/datasciencebr/serenata-de-amor" target="_blank">{% t footer.github %}</a>
         <a href="https://www.facebook.com/operacaoSerenataDeAmor/" target="_blank">{% t footer.facebook %}</a>
         <a href="mailto:contato@serenata.ai" target="_blank">{% t footer.contact %}</a>


### PR DESCRIPTION
I noticed the Jarbas URL on the website's footer was no longer working, it seems the website now runs on  the serenata.ai domain: https://jarbas.serenata.ai/